### PR TITLE
Update conditionals for bindNoticeDialog

### DIFF
--- a/jquery.remember-state.js
+++ b/jquery.remember-state.js
@@ -108,7 +108,7 @@
       return values;
     },
     bindNoticeDialog: function() {
-      if (!this.noticeDialog || this.noticeDialog.length || !this.noticeDialog.jquery) {
+      if (!this.noticeDialog || !this.noticeDialog.length || !this.noticeDialog.jquery) {
         this.noticeDialog = this._defaultNoticeDialog();
       }
       this.noticeDialog.find("a").bind("click." + this.name, {


### PR DESCRIPTION
`noticeDialog` option doesn't work in the current state.
Changing `this.noticeDialog.length` to `!this.noticeDialog.length`
corrects this.
